### PR TITLE
Fix ExtractIPAddresses IPv6 regexp

### DIFF
--- a/src/core/operations/ExtractIPAddresses.mjs
+++ b/src/core/operations/ExtractIPAddresses.mjs
@@ -66,7 +66,7 @@ class ExtractIPAddresses extends Operation {
     run(input, args) {
         const [includeIpv4, includeIpv6, removeLocal, displayTotal, sort, unique] = args,
             ipv4 = "(?:(?:\\d|[01]?\\d\\d|2[0-4]\\d|25[0-5])\\.){3}(?:25[0-5]|2[0-4]\\d|[01]?\\d\\d|\\d)(?:\\/\\d{1,2})?",
-            ipv6 = "((?=.*::)(?!.*::.+::)(::)?([\\dA-F]{1,4}:(:|\\b)|){5}|([\\dA-F]{1,4}:){6})((([\\dA-F]{1,4}((?!\\3)::|:\\b|(?![\\dA-F])))|(?!\\2\\3)){2}|(((2[0-4]|1\\d|[1-9])?\\d|25[0-5])\\.?\\b){4})";
+            ipv6 = "((?=.*::)(?!.*::.+::)(::)?([\\dA-F]{1,4}:(:|\\b)|){5}|([\\dA-F]{1,4}:){6})(([\\dA-F]{1,4}((?!\\3)::|:\\b|(?![\\dA-F])))|(?!\\2\\3)){2}";
         let ips  = "";
 
         if (includeIpv4 && includeIpv6) {


### PR DESCRIPTION
IPv6 regexp shouldn't match IPv4 address.

[https://gchq.github.io/CyberChef/#recipe=Extract_IP_addresses(false,true,false,false,false,false)&input=MTI3LjAuMC4xLCBmZTgwOjoy](https://gchq.github.io/CyberChef/#recipe=Extract_IP_addresses(false,true,false,false,false,false)&input=MTI3LjAuMC4xLCBmZTgwOjoy)